### PR TITLE
- Fixed behaviour of buildnumber-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -468,6 +468,7 @@
                             <configuration>
                                 <!-- Needed when no SCM configuration is given. -->
                                 <revisionOnScmFailure>UNKNOW_REVISION</revisionOnScmFailure>
+                                <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
  to get the revision from version control only once
  in particular in a multi-module build.
