### PR TITLE
Configure maven-license-plugin to use SLASHSTAR_STYLE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,6 +531,9 @@
                         <includes>
                             <include>src/**/*.java</include>
                         </includes>
+                        <mapping>
+                            <java>SLASHSTAR_STYLE</java>
+                        </mapping>
                     </configuration>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
Right now, by default, the maven-license-plugin will require the license header in Java source files to be in JavaDoc style. This is unusual and collides with the maven-javadoc-plugin, which tries to parse the license as JavaDoc, stumbling over invalid characters, such as '&'. There is an upstream ticket which will change this default setting soon:

https://github.com/mycila/license-maven-plugin/pull/109

This PR will set the default style for Java sources to "slashstyle", i.e. simple block comments, preparing for the upstream change. Note, that this is a breaking change and users might have to adapt to it.