### PR TITLE
Activate license:check during foss-parent-verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,14 +509,24 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${maven-license-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>default-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                     <configuration>
                         <header>${maven-license-plugin.header}</header>
                         <strictCheck>true</strictCheck>
                         <includes>
                             <include>src/**/*.java</include>
+                            <include>src/**/*.groovy</include>
                         </includes>
                         <mapping>
                             <java>SLASHSTAR_STYLE</java>
+                            <groovy>SLASHSTAR_STYLE</groovy>
                         </mapping>
                     </configuration>
                     <dependencies>
@@ -1041,13 +1051,6 @@
                     <plugin>
                         <groupId>com.mycila</groupId>
                         <artifactId>license-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -1133,6 +1136,10 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                    </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>buildnumber-maven-plugin</artifactId>

--- a/src/it/check-site-jacoco/verify.groovy
+++ b/src/it/check-site-jacoco/verify.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1&1 Internet AG, https://github.com/1and1/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // File basedir = new File( "." );
 File file = new File( basedir, "build.log" );
 assert file.exists();

--- a/src/it/check-without-verification/verify.groovy
+++ b/src/it/check-without-verification/verify.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1&1 Internet AG, https://github.com/1and1/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 File file = new File( basedir, "build.log" );
 assert file.exists();
 

--- a/src/it/spring-boot/src/test/groovy/net/oneandone/maven/poms/sampleprojectspringboot/SpockTest.groovy
+++ b/src/it/spring-boot/src/test/groovy/net/oneandone/maven/poms/sampleprojectspringboot/SpockTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1&1 Internet AG, https://github.com/1and1/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.oneandone.maven.poms.sampleprojectspringboot
 
 import spock.lang.Specification

--- a/src/it/spring-boot/verify.groovy
+++ b/src/it/spring-boot/verify.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 1&1 Internet AG, https://github.com/1and1/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // File basedir = new File( "." );
 File file = new File(basedir, "build.log")
 File targetDir = new File(basedir, "target")


### PR DESCRIPTION
* Currently license:check is only invoked during the release process, this leads to very late feedback.
* So move it to `foss-parent-verification` profile
* Additionally check groovy files as well.